### PR TITLE
Add parameter to {docker}.Client.ContainerCreate()

### DIFF
--- a/toolGear/dockerStruct.go
+++ b/toolGear/dockerStruct.go
@@ -1139,5 +1139,4 @@ func (d *Docker) NetworkCreate(name string, options types.NetworkCreate) *ux.Sta
 
 func _close(c io.Closer) {
 	_ = c.Close()
-
 }


### PR DESCRIPTION
Add parameter for calls to `{docker}.Client.ContainerCreate()` for a newly added `*specs.Platform` parameter found in the Docker client package `v20.10.6`. This issue requires issue #2 to be resolved.

Issue: #3